### PR TITLE
(Ref) #8 refactored decode image in order to reduce Cyclomatic

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/icns/IcnsDecoder.java
+++ b/src/main/java/org/apache/commons/imaging/formats/icns/IcnsDecoder.java
@@ -206,22 +206,24 @@ final class IcnsDecoder {
             throws ImageReadException {
         final IcnsImageParser.IcnsElement imageElement = icnsElements[index];
         final IcnsType imageType = IcnsType.findImageType(imageElement.type);
+
+        //refactored in order to use contains instead of 11 conditions to reduce Cyclomatic complexity
+        ArrayList<IcnsType> IcnsTypeList = new ArrayList<>();
+        IcnsTypeList.add(IcnsType.ICNS_16x16_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_32x32_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_64x64_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_128x128_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_256x256_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_512x512_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_1024x1024_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_32x32_2x_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_64x64_2x_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_256x256_2x_32BIT_ARGB_IMAGE);
+        IcnsTypeList.add(IcnsType.ICNS_512x512_2x_32BIT_ARGB_IMAGE);
         if (imageType == null) {
             return null;
         }
-
-        // PNG or JPEG 2000
-        if (imageType == IcnsType.ICNS_16x16_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_32x32_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_64x64_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_128x128_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_256x256_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_512x512_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_1024x1024_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_32x32_2x_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_64x64_2x_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_256x256_2x_32BIT_ARGB_IMAGE
-            || imageType == IcnsType.ICNS_512x512_2x_32BIT_ARGB_IMAGE) {
+        if(IcnsTypeList.contains(imageType)){
             BufferedImage image = null;
             try {
                 image = Imaging.getBufferedImage(imageElement.data);


### PR DESCRIPTION
Complexity from 17 to 7 (> 35%). This was done trough usage of araylist.contains instead of having 11 conditions. closes #8